### PR TITLE
Add simulation module and summary display

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<title>Omise Proto</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<canvas id="game" width="800" height="600"></canvas>
+<script type="module" src="js/main.js"></script>
+</body>
+</html>

--- a/js/engine/data.js
+++ b/js/engine/data.js
@@ -1,0 +1,37 @@
+export const data = {
+  locations: [
+    { id: 'takane-forest', name: '高嶺の森' }
+  ],
+  gatherEvents: {
+    'takane-forest': [
+      { roll_low: 1, roll_high: 10, action: '落ち枝を拾う', loot_table_id: 'lt-forest-common' },
+      { roll_low: 11, roll_high: 20, action: '湿った藪を探す', loot_table_id: 'lt-forest-rain' },
+      { roll_low: 21, roll_high: 100, action: '河原の石を集める', loot_table_id: 'lt-forest-common' }
+    ]
+  },
+  lootTables: {
+    'lt-forest-common': [
+      { item_id: 'tsuchi-ishi', weight: 50, qty_min: 1, qty_max: 2 },
+      { item_id: 'hinoki-leaf', weight: 50, qty_min: 1, qty_max: 3 }
+    ],
+    'lt-forest-rain': [
+      { item_id: 'hinoki-leaf', weight: 70, qty_min: 1, qty_max: 3 },
+      { item_id: 'tsuchi-ishi', weight: 20, qty_min: 1, qty_max: 2 },
+      { item_id: 'rare-mushroom', weight: 10, qty_min: 1, qty_max: 2 }
+    ]
+  },
+  recipes: [
+    {
+      id: 'make-stone-charm',
+      name: '護符加工',
+      input: [{ id: 'tsuchi-ishi', qty: 1 }],
+      output: [{ id: 'stone-charm', qty: 1 }]
+    }
+  ],
+  items: {
+    'tsuchi-ishi': { name: '土石' },
+    'hinoki-leaf': { name: '檜葉' },
+    'rare-mushroom': { name: '珍しいキノコ' },
+    'stone-charm': { name: '石護符', base_price: 50 }
+  }
+};

--- a/js/engine/sim.js
+++ b/js/engine/sim.js
@@ -1,0 +1,51 @@
+import { RNG } from '../rng.js';
+import { data } from './data.js';
+import { gather, craft, sell } from './systems.js';
+
+function createSimState(seed) {
+  return {
+    inventory: {},
+    money: 0,
+    day: 1,
+    logs: [],
+    rng: new RNG(seed),
+    flags: { gathered: false, crafted: false, sold: false }
+  };
+}
+
+export function runSimulation(runs = 500, days = 100) {
+  let totalProfit = 0;
+  let bankruptcies = 0;
+  let totalTurnover = 0;
+
+  for (let r = 0; r < runs; r++) {
+    const state = createSimState(r + 1);
+    let sold = 0;
+    let inventoryAccum = 0;
+    let bankrupted = false;
+
+    for (let d = 0; d < days; d++) {
+      gather(state, data);
+      craft(state, data);
+      const beforeMoney = state.money;
+      sell(state, data);
+      const afterMoney = state.money;
+      if (afterMoney > beforeMoney) sold += 1;
+      const inventoryTotal = Object.values(state.inventory).reduce((a, b) => a + b, 0);
+      inventoryAccum += inventoryTotal;
+      if (state.money < 0) bankrupted = true;
+    }
+
+    const avgInventory = inventoryAccum / days;
+    const turnover = avgInventory > 0 ? sold / avgInventory : 0;
+    totalTurnover += turnover;
+    totalProfit += state.money;
+    if (bankrupted) bankruptcies += 1;
+  }
+
+  return {
+    averageProfit: totalProfit / runs,
+    bankruptcyRate: bankruptcies / runs,
+    averageInventoryTurnover: totalTurnover / runs
+  };
+}

--- a/js/engine/state.js
+++ b/js/engine/state.js
@@ -1,0 +1,28 @@
+import { RNG } from '../rng.js';
+
+export function createState(seed) {
+  const raw = localStorage.getItem('omise-save');
+  if (raw) {
+    const obj = JSON.parse(raw);
+    obj.rng = new RNG(seed);
+    return obj;
+  }
+  return {
+    tabIndex: 0,
+    tabs: ['home', 'gather', 'craft', 'shop'],
+    menuIndex: 0,
+    logs: [],
+    inventory: {},
+    money: 0,
+    day: 1,
+    reputation: 0,
+    rng: new RNG(seed),
+    flags: { gathered: false, crafted: false, sold: false }
+  };
+}
+
+export function saveState(state) {
+  const copy = { ...state };
+  delete copy.rng;
+  localStorage.setItem('omise-save', JSON.stringify(copy));
+}

--- a/js/engine/systems.js
+++ b/js/engine/systems.js
@@ -1,0 +1,59 @@
+
+function pickEvent(events, rng) {
+  const roll = Math.floor(rng.next() * 100) + 1;
+  return events.find(e => roll >= e.roll_low && roll <= e.roll_high) || events[0];
+}
+
+function pickLoot(table, rng) {
+  const total = table.reduce((s, e) => s + e.weight, 0);
+  let r = rng.next() * total;
+  for (const entry of table) {
+    if ((r -= entry.weight) < 0) {
+      const qty = entry.qty_min + rng.nextInt(entry.qty_max - entry.qty_min + 1);
+      return { id: entry.item_id, qty };
+    }
+  }
+  const first = table[0];
+  return { id: first.item_id, qty: first.qty_min };
+}
+
+export function gather(state, data) {
+  const locId = data.locations[0].id;
+  const events = data.gatherEvents[locId];
+  const ev = pickEvent(events, state.rng);
+  const loot = pickLoot(data.lootTables[ev.loot_table_id], state.rng);
+  state.inventory[loot.id] = (state.inventory[loot.id] || 0) + loot.qty;
+  state.logs.push(`${ev.action} → ${data.items[loot.id].name} x${loot.qty}`);
+  state.flags.gathered = true;
+}
+
+export function craft(state, data) {
+  const recipe = data.recipes[0];
+  const need = recipe.input[0];
+  if ((state.inventory[need.id] || 0) >= need.qty) {
+    state.inventory[need.id] -= need.qty;
+    const out = recipe.output[0];
+    state.inventory[out.id] = (state.inventory[out.id] || 0) + out.qty;
+    state.logs.push(`${recipe.name} → ${data.items[out.id].name} x${out.qty}`);
+    state.flags.crafted = true;
+  } else {
+    state.logs.push('材料が不足しています');
+  }
+}
+
+export function sell(state, data) {
+  const id = 'stone-charm';
+  if (state.inventory[id]) {
+    state.inventory[id] -= 1;
+    state.money += data.items[id].base_price;
+    state.logs.push(`販売 → +${data.items[id].base_price}G`);
+    state.flags.sold = true;
+    if (state.flags.gathered && state.flags.crafted && state.flags.sold) {
+      state.logs.push('1日が終了しました');
+      state.day += 1;
+      state.flags = { gathered: false, crafted: false, sold: false };
+    }
+  } else {
+    state.logs.push('商品がありません');
+  }
+}

--- a/js/input.js
+++ b/js/input.js
@@ -1,0 +1,16 @@
+export function setupInput(state, getMenuOptions, onSelect) {
+  window.addEventListener('keydown', e => {
+    const opts = getMenuOptions();
+    if (e.key === 'ArrowUp') {
+      state.menuIndex = (state.menuIndex - 1 + opts.length) % opts.length;
+    } else if (e.key === 'ArrowDown') {
+      state.menuIndex = (state.menuIndex + 1) % opts.length;
+    } else if (e.key === 'Enter') {
+      onSelect();
+    } else if (e.key === 'Tab') {
+      e.preventDefault();
+      state.tabIndex = (state.tabIndex + 1) % state.tabs.length;
+      state.menuIndex = 0;
+    }
+  });
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,47 @@
+import { createState, saveState } from './engine/state.js';
+import { data } from './engine/data.js';
+import { draw } from './renderer.js';
+import { setupInput } from './input.js';
+import { gather, craft, sell } from './engine/systems.js';
+import { runSimulation } from './engine/sim.js';
+
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+
+const seed = Number(new URLSearchParams(window.location.search).get('seed')) || Date.now();
+const state = createState(seed);
+const simSummary = runSimulation();
+
+function getMenuOptions() {
+  const tab = state.tabs[state.tabIndex];
+  if (tab === 'gather') {
+    return state.flags.gathered ? ['採取済み'] : ['高嶺の森'];
+  } else if (tab === 'craft') {
+    if (state.flags.crafted) return ['クラフト済み'];
+    return state.inventory['tsuchi-ishi'] ? ['護符加工'] : ['材料不足'];
+  } else if (tab === 'shop') {
+    if (state.flags.sold) return ['販売済み'];
+    return state.inventory['stone-charm'] ? ['石護符を売る'] : ['商品なし'];
+  }
+  return ['Tabで画面切替'];
+}
+
+function onSelect() {
+  const tab = state.tabs[state.tabIndex];
+  if (tab === 'gather' && !state.flags.gathered) {
+    gather(state, data);
+  } else if (tab === 'craft' && !state.flags.crafted) {
+    craft(state, data);
+  } else if (tab === 'shop' && !state.flags.sold) {
+    sell(state, data);
+  }
+  saveState(state);
+}
+
+setupInput(state, getMenuOptions, onSelect);
+
+function loop() {
+  draw(ctx, state, getMenuOptions(), simSummary);
+  requestAnimationFrame(loop);
+}
+loop();

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -1,0 +1,31 @@
+export function draw(ctx, state, menuOptions, simSummary) {
+  ctx.clearRect(0, 0, 800, 600);
+  ctx.fillStyle = '#222';
+  ctx.fillRect(0, 0, 800, 600);
+  ctx.font = '16px monospace';
+  // menu
+  menuOptions.forEach((opt, i) => {
+    ctx.fillStyle = i === state.menuIndex ? '#ff0' : '#fff';
+    ctx.fillText(opt, 20, 40 + i * 20);
+  });
+  // right panel
+  ctx.fillStyle = '#fff';
+  let y = 40;
+  ctx.fillText(`Day: ${state.day}`, 420, y); y += 20;
+  ctx.fillText(`Money: ${state.money}`, 420, y); y += 20;
+  ctx.fillText('Inventory:', 420, y); y += 20;
+  Object.entries(state.inventory).forEach(([id, qty]) => {
+    ctx.fillText(`${id}: ${qty}`, 420, y); y += 20;
+  });
+  if (simSummary) {
+    y += 20;
+    ctx.fillText(`Avg Profit: ${simSummary.averageProfit.toFixed(1)}`, 420, y); y += 20;
+    ctx.fillText(`Bankruptcy: ${(simSummary.bankruptcyRate * 100).toFixed(1)}%`, 420, y); y += 20;
+    ctx.fillText(`Inv Turn: ${simSummary.averageInventoryTurnover.toFixed(2)}`, 420, y); y += 20;
+  }
+  // log
+  const start = Math.max(0, state.logs.length - 8);
+  state.logs.slice(start).forEach((msg, i) => {
+    ctx.fillText(msg, 20, 330 + i * 20);
+  });
+}

--- a/js/rng.js
+++ b/js/rng.js
@@ -1,0 +1,12 @@
+export class RNG {
+  constructor(seed = Date.now()) {
+    this.seed = seed >>> 0;
+  }
+  next() {
+    this.seed = (1664525 * this.seed + 1013904223) % 4294967296;
+    return this.seed / 4294967296;
+  }
+  nextInt(max) {
+    return Math.floor(this.next() * max);
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,10 @@
+body {
+  margin: 0;
+  background: #000;
+  color: #fff;
+  font-family: monospace;
+}
+canvas {
+  display: block;
+  margin: 0 auto;
+}


### PR DESCRIPTION
## Summary
- Simulate 500 runs of 100-day cycles to estimate profit, bankruptcy rate, and inventory turnover
- Show simulation summary on the canvas right panel alongside player stats

## Testing
- `node --experimental-modules -e "import('./js/engine/sim.js').then(m=>console.log(m.runSimulation(5,10)))"`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1192634ac832e8706857b7222dab6