### PR TITLE
Simplify prototype with tabbed gather-craft-sell loop

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <title>和名×ファンタジー・採取クラフト経営(Prototype)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <canvas id="gameCanvas" width="800" height="600" aria-label="Game UI"></canvas>
+  <script type="module" src="./js/main.js"></script>
+</body>
+</html>

--- a/js/engine/data.js
+++ b/js/engine/data.js
@@ -1,0 +1,34 @@
+export function makeData(){
+  // 超最小のサンプル：砂→ガラス、油→石鹸（※安全配慮で抽象化）
+  return {
+    materials: [
+      {id:"sand", name_ja:"砂", name_en:"sand"},
+      {id:"oil",  name_ja:"植物油", name_en:"vegetable_oil"}
+    ],
+    items: [
+      {id:"glass", name_ja:"ガラス", name_en:"glass"},
+      {id:"soap",  name_ja:"石鹸",   name_en:"soap"}
+    ],
+    recipes: [
+      {
+        id:"glass_basic", name_ja:"ガラス基礎精製",
+        inputs:[{id:"sand",qty:2}],
+        outputs:[{id:"glass",qty:1}],
+        tools:["炉"], conditions:{tempC:1200,timeMin:60,notes:"現実は高温。ゲームでは抽象化"},
+        safety_notes:"高温工程のため抽象化し詳細省略"
+      },
+      {
+        id:"soap_basic", name_ja:"石鹸の素",
+        inputs:[{id:"oil",qty:1}],
+        outputs:[{id:"soap",qty:1}],
+        tools:["鍋"], conditions:{tempC:70,timeMin:30,notes:"苛性ソーダ工程は抽象化"},
+        safety_notes:"薬品工程は抽象化。詳細配合は非表示"
+      }
+    ],
+    demand:{
+      glass: { base: 5, season:{spring:1,summer:1.1,autumn:0.9,winter:1}, weather:{sunny:1,rainy:1,storm:0.8} },
+      soap:  { base: 4, season:{spring:1,summer:1.2,autumn:1,winter:0.9}, weather:{sunny:1,rainy:1.1,storm:0.9} }
+    },
+    prices:{ glass:{buy:0, sell:30}, soap:{buy:0, sell:22} }
+  };
+}

--- a/js/engine/state.js
+++ b/js/engine/state.js
@@ -1,0 +1,23 @@
+import { seeded } from "../rng.js";
+import { makeData } from "./data.js";
+
+export function newGameState(){
+  const data = makeData();
+  return {
+    data,
+    rng: seeded(12345),
+    calendar: { day: 1, season: "spring" },
+    world: { weather: "sunny", reputation: 0 },
+    player: { stamina: 100, skill: 1 },
+    money: 200,
+    inv: { sand: 5, oil: 2, glass:0, soap:0 },
+    ui: { tab: 0, cursor: 0, log: ["— 初日 —"], message:"" }
+  };
+}
+export function nextDay(G){
+  G.calendar.day++;
+  // 超簡易：天候ローテ
+  const order = ["sunny","rainy","storm","sunny","sunny","rainy"];
+  G.world.weather = order[G.calendar.day % order.length];
+  G.player.stamina = Math.min(100, G.player.stamina+20);
+}

--- a/js/engine/systems.js
+++ b/js/engine/systems.js
@@ -1,0 +1,48 @@
+export class Systems{
+  gatherOnce(G){
+    if(G.player.stamina < 10) return {ok:false,msg:"体力不足で採取できない"};
+    G.player.stamina -= 10;
+    // 天候補正：雨なら砂-1、油+0（仮）
+    let sandGain = (G.world.weather==="storm")?0:1;
+    G.inv.sand = (G.inv.sand||0) + sandGain;
+    // 低確率で油
+    if(rand(G) < 0.25) G.inv.oil = (G.inv.oil||0) + 1;
+    return {ok:true,msg:`砂+${sandGain}${(G.inv.oil&&rand(G)<0.5)?" / 油+1":""}`};
+  }
+  craftOnce(G){
+    // 優先：ガラス→石鹸
+    const rGlass = canDo("glass_basic", G);
+    if(rGlass){ useInputs(rGlass, G); addOutputs(rGlass, G); return {ok:true,msg:"ガラスを精製した"}; }
+    const rSoap = canDo("soap_basic", G);
+    if(rSoap){ useInputs(rSoap, G); addOutputs(rSoap, G); return {ok:true,msg:"石鹸を作った"}; }
+    return {ok:false,msg:"材料が足りない"};
+  }
+  sellOnce(G){
+    // 需要= base * season * weather（評判は未導入）
+    const d = G.data.demand;
+    let sold=0, money=0;
+    for(const id of ["glass","soap"]){
+      const have = G.inv[id]||0; if(!have) continue;
+      const dm = d[id];
+      const demandToday = Math.round(dm.base * dm.season.spring * dm.weather[G.world.weather]);
+      const q = Math.min(have, demandToday);
+      G.inv[id] -= q; sold += q;
+      const price = G.data.prices[id].sell;
+      money += q*price;
+    }
+    G.money += money;
+    return {ok:true,msg:`${sold}個を販売して${money}G稼いだ`};
+  }
+}
+
+function rand(G){ return G.rng(); }
+
+function canDo(recipeId, G){
+  const r = G.data.recipes.find(x=>x.id===recipeId); if(!r) return null;
+  for(const inp of r.inputs){
+    if((G.inv[inp.id]||0) < inp.qty) return null;
+  }
+  return r;
+}
+function useInputs(r,G){ for(const inp of r.inputs){ G.inv[inp.id]-=inp.qty; } }
+function addOutputs(r,G){ for(const o of r.outputs){ G.inv[o.id]=(G.inv[o.id]||0)+o.qty; } }

--- a/js/input.js
+++ b/js/input.js
@@ -1,0 +1,16 @@
+const pressed = new Set();
+let lastOnce = null;
+
+export function initInput(){
+  window.addEventListener("keydown", (e)=>{
+    if (["ArrowUp","ArrowDown","Enter","Tab","Escape"].includes(e.key)) {
+      pressed.add(e.key);
+      lastOnce = e.key;
+      e.preventDefault();
+    }
+  }, {passive:false});
+  window.addEventListener("keyup", (e)=> pressed.delete(e.key));
+  return { };
+}
+export function getInputOnce(){ const k = lastOnce; lastOnce = null; return k; }
+export function clearPressed(){ pressed.clear(); }

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,58 @@
+import { initInput, getInputOnce, clearPressed } from "./input.js";
+import { Renderer } from "./renderer.js";
+import { newGameState, nextDay } from "./engine/state.js";
+import { Systems } from "./engine/systems.js";
+
+const canvas = document.getElementById("gameCanvas");
+const ctx = canvas.getContext("2d");
+ctx.imageSmoothingEnabled = false;
+
+const input = initInput();
+const ren = new Renderer(ctx);
+const sys = new Systems();
+
+const G = newGameState();
+
+function tick(ts){
+  update(1/60);
+  render();
+  requestAnimationFrame(tick);
+}
+requestAnimationFrame(tick);
+
+function update(dt){
+  const key = getInputOnce();
+  if(key === "Tab") {
+    const tabs = ["拠点","採取","クラフト","店舗"];
+    G.ui.tab = (G.ui.tab + 1) % tabs.length;
+    G.ui.message = `画面: ${tabs[G.ui.tab]}`;
+  }
+  if(key === "ArrowUp")    G.ui.cursor = Math.max(0, G.ui.cursor-1);
+  if(key === "ArrowDown")  G.ui.cursor = Math.min(3, G.ui.cursor+1);
+
+  if(key === "Enter"){
+    const tab = G.ui.tab;
+    if(tab===0){ // 拠点
+      G.ui.log.push("休息して体力を少し回復した。");
+      G.player.stamina = Math.min(100, G.player.stamina+10);
+    }else if(tab===1){ // 採取
+      const r = sys.gatherOnce(G);
+      G.ui.log.push(`採取: ${r.msg}`);
+    }else if(tab===2){ // クラフト
+      const r = sys.craftOnce(G);
+      G.ui.log.push(`クラフト: ${r.msg}`);
+    }else if(tab===3){ // 店舗
+      const r = sys.sellOnce(G);
+      G.ui.log.push(`販売: ${r.msg}`);
+      nextDay(G);
+      G.ui.log.push(`— 翌日(${G.calendar.day}) —`);
+    }
+  }
+  clearPressed();
+}
+
+function render(){
+  ren.clear();
+  ren.drawFrame();
+  ren.drawPanels(G);
+}

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -1,0 +1,32 @@
+export class Renderer{
+  constructor(ctx){ this.ctx = ctx; this.font = "16px ui-monospace, Consolas, monospace"; }
+  clear(){ const c=this.ctx.canvas; this.ctx.clearRect(0,0,c.width,c.height); }
+  drawFrame(){
+    const c=this.ctx.canvas, g=this.ctx;
+    g.strokeStyle="#3a3f46"; g.lineWidth=2;
+    // 左メニュー
+    g.strokeRect(12,12,260,400);
+    // 右ステータス
+    g.strokeRect(280,12,508,180);
+    // 下ログ
+    g.strokeRect(12,420,776,168);
+  }
+  drawPanels(G){
+    const g=this.ctx;
+    g.fillStyle="#ddd"; g.font=this.font;
+    // メニュー
+    const tabs = ["拠点","採取","クラフト","店舗"];
+    g.fillText(`画面: ${tabs[G.ui.tab]}  (Tabで切替)`, 24, 36);
+    const menu = ["[Enter] 決定","↑↓ カーソル移動","Tab 画面切替",""];
+    menu.forEach((t,i)=> g.fillText(t, 24, 70+i*22));
+    // ステータス
+    let y=40;
+    g.fillText(`日付: ${G.calendar.day}日  天候: ${G.world.weather}`, 296, y); y+=24;
+    g.fillText(`体力: ${G.player.stamina}`, 296, y); y+=24;
+    g.fillText(`所持金: ${G.money}`, 296, y); y+=24;
+    g.fillText(`在庫: ガラス:${G.inv.glass||0} / 石鹸:${G.inv.soap||0} / 砂:${G.inv.sand||0} / 油:${G.inv.oil||0}`, 296, y);
+    // ログ
+    const log = G.ui.log.slice(-6);
+    log.forEach((t,i)=> g.fillText(t, 24, 452+i*22));
+  }
+}

--- a/js/rng.js
+++ b/js/rng.js
@@ -1,0 +1,10 @@
+export function seeded(seed){
+  let s = seed>>>0;
+  return function(){
+    // xorshift32
+    s ^= s << 13; s >>>= 0;
+    s ^= s >> 17; s >>>= 0;
+    s ^= s << 5;  s >>>= 0;
+    return (s>>>0) / 0xFFFFFFFF;
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,2 @@
+html,body{margin:0;background:#0b0d10;color:#ddd;font-family:ui-monospace,Consolas,monospace}
+canvas{display:block;margin:16px auto;border:2px solid #333;border-radius:8px;background:#0e1116}


### PR DESCRIPTION
## Summary
- Replace HTML and style for single canvas prototype with ES modules
- Implement tabbed gather/craft/sell loop with renderer, input, state, and systems
- Seeded RNG and minimal data for glass and soap crafting

## Testing
- `node --input-type=module -e "import('./js/engine/state.js').then(async ({newGameState})=>{const G=newGameState(); const {Systems}=await import('./js/engine/systems.js'); const sys=new Systems(); console.log(sys.gatherOnce(G)); console.log(sys.craftOnce(G)); console.log(sys.sellOnce(G));});"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1192634ac832e8706857b7222dab6